### PR TITLE
클래스 생성 구문

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -64,7 +64,10 @@ impl<'a> Parser<'a> {
     }*/
 
     fn past_token_is(&mut self, token: &Token) -> bool {
-        token == self.past_token()
+        if self.position > 0 {
+            return token == self.past_token();
+        }
+        false
     }
 
     fn cur_token_is(&mut self, token: &Token) -> bool {
@@ -637,7 +640,7 @@ impl<'a> Parser<'a> {
 
         // class 초기화
         if let Some(Expression::Identifier(_)) = left.clone() {
-            if self.past_token_is(&Token::Return) {
+            if !self.past_token_is(&Token::Class) {
                 match self.future_token() {
                     Token::OpenBrace => {
                         self.consume_token();


### PR DESCRIPTION
identifier 의 이전 토큰이 class 가 아니고 이후 토큰이 '{' 인 경우 class 생성 구문으로 인식. 또한 이전 토큰을 확인할 때, position 이 0 인 경우 오류 해결